### PR TITLE
resize div and img tags on mobile

### DIFF
--- a/style/section2.css
+++ b/style/section2.css
@@ -83,7 +83,7 @@ body {
     #about_me {
         height: 62%;
 
-        margin-top: -90%;
+        top: -38%;
         margin-left: 7%;
     }
 
@@ -98,7 +98,7 @@ body {
     #borderAboutMe {
         content: url("../images/smallBorder.png");
         width: 96%;
-        top: 33%;
+        top: 34%;
         left: 4%;
 
     }


### PR DESCRIPTION
I had to redefine the size and position of the `div` and `img` tags due to changing their default style (pc), which ended up affecting mobile