### PR TITLE
Fix a white "border"

### DIFF
--- a/style/section1.css
+++ b/style/section1.css
@@ -1,3 +1,7 @@
+html {
+    background-color: #2F3C3A;
+}
+
 #section1 {
     position: relative;
 


### PR DESCRIPTION
The problem is that `section1` and `section 2` are not distributed by 30/70 and there is a white space between them. To resolve this, the default color of the `html` tag was changed to gray-green, matching the two sections.