### PR TITLE
Fix wrong style application

### DIFF
--- a/effect/changeUrl.js
+++ b/effect/changeUrl.js
@@ -2,7 +2,7 @@ const semicircle = document.getElementById("semicircle")
 const topLines = document.getElementById("topLines")
 const background = document.getElementById("section2_5")
 
-if (window.screen.width >= 412) {
+if (window.screen.width <= 412) {
     semicircle.setAttribute("src","./images/semicircle2.svg")
     topLines.setAttribute("src","./images/topLines2.svg")
     background.style.backgroundImage = "url(./images/background4.svg)"


### PR DESCRIPTION
The application of the image style on mobile was being applied in PC mode.

Fixed changing the ">=" sign to "<=", to be applied only on mobile